### PR TITLE
Fix typo on action generator template name

### DIFF
--- a/lib/generators/avo/action_generator.rb
+++ b/lib/generators/avo/action_generator.rb
@@ -7,7 +7,7 @@ module Generators
       namespace "avo:action"
 
       def create_resource_file
-        template "action.rb", "app/avo/actions/#{singular_name}.rb"
+        template "action.tt", "app/avo/actions/#{singular_name}.rb"
       end
     end
   end


### PR DESCRIPTION
Running the action generator leads to the following error 
```
bin/rails generate avo:action toggle_published

Could not find "action.rb" in any of your source paths. Your current source paths are: 
~/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/avo-1.2.10/lib/generators/avo/templates
```